### PR TITLE
Add list_tag_items_all command

### DIFF
--- a/exe/list_tag_items_all
+++ b/exe/list_tag_items_all
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+if [ $# -ne 1 ]; then
+  echo "Usage: list_tag_items_all TAG"
+  exit 1
+fi
+
+tag=$1
+per_page=100
+page=1
+
+while :
+do
+  items=$(qiita list_tag_items $tag per_page=$per_page page=$page -t $QIITA_TEAM | jq -r '.[] | .user.id + "," + .title')
+  if [ -z "$items" ]; then
+    break
+  fi
+  echo "$items"
+  page=$((page + 1))
+done


### PR DESCRIPTION
指定されたタグがついている記事を全て出力するコマンドを追加しました。

## Requirements

- jqコマンドがインストールされていること
- qiita gemがインストールされていること
- 環境変数の`QIITA_TEAM`にチーム名が設定されていること
- 環境変数の`QIITA_ACCESS_TOKEN`にアクセストークンが設定されていること

## Installation (macOS)

`QIITA_ACCESS_TOKEN`は https://qiita.com/settings/applications で`read_qiita_team`に ✅ を入れたものを発行

```
% brew install jq envchain
% gem install qiita
% envchain --set qiita-team-reporter QIITA_ACCESS_TOKEN QIITA_TEAM
```

## Examples

hanachin_の日報だけ取る場合

```
% envchain qiita-team-reporter exe/list_tag_items_all 日報/2017/09 | grep hanachin_ | sort | cut -d, -f2-
```

## `exe`ディレクトリに入っている理由

パスが通しやすいように実行可能ファイルを`exe`ディレクトリに入れています。