### PR TITLE
Use list_tag_items_all command directly

### DIFF
--- a/exe/list_daily_reports
+++ b/exe/list_daily_reports
@@ -2,7 +2,7 @@
 
 list_daily_reports() {
     # Show given user's daily repots this month
-    ./list_tag_items_all "日報/$(date +%Y/%m)" | grep $1 | sort | cut -d, -f2-
+    list_tag_items_all "日報/$(date +%Y/%m)" | grep $1 | sort | cut -d, -f2-
 }
 
 # Check number of given arguments


### PR DESCRIPTION
パスを通して使ってほしいので Remove ./ prefix from USAGE #5 でUSAGE直したのですが、シェルの関数ないでカレントディレクトリにコマンドがある想定で書かれていて動かなくなっていました。
パス通ってるコマンドが使えるよう`./`を削除しました。